### PR TITLE
Updates for tox 4

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -5,3 +5,4 @@
 31-Dec-2020  V0.22 - Avoid directory purge on image generation
  1-Jan-2021  V0.23 - Handle missing categories in extension dictionaries within category images.
  1-Jan-2021  V0.24 - Add NX_Mapping details for cif_img.dic
+10-Jan-2023  V0.25 - Configuration changes to support tox 4, graphviz env variable for testing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mmCIF Dictionary Site Generator
 
-[![Build Status](https://dev.azure.com/rcsb/RCSB%20PDB%20Python%20Projects/_apis/build/status/rcsb.py-mmcif_sitegen?branchName=dev-20201227)](https://dev.azure.com/rcsb/RCSB%20PDB%20Python%20Projects/_build/latest?definitionId=30&branchName=dev-20201227)
+[![Build Status](https://dev.azure.com/rcsb/RCSB%20PDB%20Python%20Projects/_apis/build/status/rcsb.py-mmcif_sitegen?branchName=master)](https://dev.azure.com/rcsb/RCSB%20PDB%20Python%20Projects/_build/latest?definitionId=30&branchName=master)
 
 ## Introduction
 

--- a/mmcif/sitegen/dictionary/__init__.py
+++ b/mmcif/sitegen/dictionary/__init__.py
@@ -2,6 +2,6 @@ __docformat__ = "restructuredtext en"
 __author__ = "John Westbrook"
 __email__ = "john.westbrook@rcsb.org"
 __license__ = "Apache 2.0"
-__version__ = "0.24"
+__version__ = "0.25"
 
 __apiUrl__ = "https://mmcif.wwpdb.org"

--- a/pylintrc
+++ b/pylintrc
@@ -68,11 +68,7 @@ disable=missing-docstring,
         unpacking-in-except,
         old-raise-syntax,
         backtick,
-        long-suffix,
-        old-ne-operator,
-        old-octal-literal,
         import-star-module-level,
-        non-ascii-bytes-literal,
         raw-checker-failed,
         bad-inline-option,
         locally-disabled,
@@ -121,7 +117,6 @@ disable=missing-docstring,
         range-builtin-not-iterating,
         filter-builtin-not-iterating,
         using-cmp-argument,
-        eq-without-hash,
         div-method,
         idiv-method,
         rdiv-method,
@@ -332,13 +327,6 @@ max-line-length=185
 
 # Maximum number of lines in a module.
 max-module-lines=1000
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ coverage_cutoff = 65
 #          23-Nov-2019 jdw py27->py38 update black version
 #          14-May-2020 jdw simplifying test runner and suppress coverage step
 #          28-Oct-2020 jdw py38->py39
+#          10-Jan-2023 aae updates for tox 4, include graphviz env
 ##
 [tox]
 # The complete list of supported test environments to setup and invoke
@@ -44,25 +45,23 @@ skip_missing_interpreters = true
 skipsdist = false
 
 [testenv]
-passenv = CONFIG_SUPPORT_TOKEN_ENV
-whitelist_externals = echo
-deps = echo
+passenv = CONFIG_SUPPORT_TOKEN_ENV,GRAPHVIZ_DOT_BINARY
+allowlist_externals = echo
 commands =
     echo "Starting default tests in testenv"
+basepython = py39: python3.9
+             py27: python2.7
 
 [testenv:py27]
 description = 'Run unit tests (unittest runner) using {envpython}'
-whitelist_externals = echo
 platform=
        macos: darwin
        linux: linux
-basepython =
-    py27: python2.7
 skip_install = false
 recreate = true
 alwayscopy=true
-usedevelop=true
-deps = echo
+package = editable-legacy
+deps =
        -r requirements.txt
 commands =
     echo "Starting {envname}"
@@ -76,17 +75,14 @@ commands =
 
 [testenv:py39]
 description = 'Run unit tests (unittest runner) using {envpython}'
-whitelist_externals = echo
 platform=
        macos: darwin
        linux: linux
-basepython =
-    py39: python3.9
 skip_install = false
 recreate = true
 alwayscopy=true
-usedevelop=true
-deps = echo
+package = editable-legacy
+deps =
        -r requirements.txt
 commands =
     echo "Starting {envname}"
@@ -104,10 +100,7 @@ description = 'Run selected PEP8 compliance checks (flake8)'
 platform=
        macos: darwin
        linux: linux
-whitelist_externals = echo
-basepython = py39: python3.9
 deps =
-    echo
     flake8
     # This plugin is no longer compatible with latest pydocstyles -
     # flake8-docstrings>=0.2.7
@@ -123,11 +116,7 @@ description = 'Run linting compliance checks (pylint)'
 platform=
        macos: darwin
        linux: linux
-whitelist_externals = echo
-basepython = py39: python3.9
-
 deps =
-    echo
     pylint
     -r requirements.txt
 commands =
@@ -141,10 +130,7 @@ description = 'Run format compliance checks (black)'
 platform=
        macos: darwin
        linux: linux
-whitelist_externals = echo
-basepython = py39: python3.9
 deps =
-    echo
     black>=20.8b1
     -r requirements.txt
     #    isort>=4.3.20
@@ -160,13 +146,10 @@ description = 'Run test coverage analysis'
 platform=
        macos: darwin
        linux: linux
-whitelist_externals = echo
-basepython = py39: python3.9
 recreate = true
 alwayscopy=true
-usedevelop=true
+package = editable-legacy
 deps =
-    echo
     coverage
     -r requirements.txt
 


### PR DESCRIPTION
Configuration updates for tox 4 and consolidation of some fields.

Using package=editable-legacy instead of usedevelop=true to avoid errors due to new packaging behavior: https://tox.wiki/en/latest/faq.html#tox-4-packaging-changes

Also removed some old pylint options that are no longer valid.

Updated readme to point to the tests for master instead of a dev branch.